### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions: contents: read` (and `pull-requests: read` for the semantic-PR action) to satisfy the `actions/missing-workflow-permissions` code scanning rule.

No functional change — the workflows previously relied on the repo's default token permissions.